### PR TITLE
Fix escaping for quotechar and escapechar

### DIFF
--- a/csvkit/cli.py
+++ b/csvkit/cli.py
@@ -198,27 +198,27 @@ class CSVKitUtility(object):
         """
         kwargs = {}
 
-        if self.args.encoding:
+        if self.args.encoding is not None:
             kwargs['encoding'] = self.args.encoding
 
-        if self.args.tabs:
+        if self.args.tabs is True:
             kwargs['delimiter'] = '\t'
-        elif self.args.delimiter:
+        elif self.args.delimiter is not None:
             kwargs['delimiter'] = self.args.delimiter
 
-        if self.args.quotechar:
+        if self.args.quotechar is not None:
             kwargs['quotechar'] = self.args.quotechar
 
-        if self.args.quoting:
+        if self.args.quoting is not None:
             kwargs['quoting'] = self.args.quoting
 
-        if self.args.doublequote:
+        if self.args.doublequote is not None:
             kwargs['doublequote'] = self.args.doublequote
 
-        if self.args.escapechar:
+        if self.args.escapechar is not None:
             kwargs['escapechar'] = self.args.escapechar
-
-        if self.args.maxfieldsize:
+        
+        if self.args.maxfieldsize is not None:
             kwargs['maxfieldsize'] = self.args.maxfieldsize
 
         return kwargs

--- a/csvkit/convert/csvitself.py
+++ b/csvkit/convert/csvitself.py
@@ -11,7 +11,7 @@ def csv2csv(f, **kwargs):
     tab = table.Table.from_csv(f, **kwargs) 
 
     o = StringIO()
-    output = tab.to_csv(o)
+    output = tab.to_csv(o, **kwargs)
     output = o.getvalue()
     o.close()
 

--- a/csvkit/convert/dbase.py
+++ b/csvkit/convert/dbase.py
@@ -33,7 +33,7 @@ def dbf2csv(f, **kwargs):
         tab = table.Table(columns=columns) 
 
         o = StringIO()
-        output = tab.to_csv(o)
+        output = tab.to_csv(o, **kwargs)
         output = o.getvalue()
         o.close()
 

--- a/csvkit/convert/fixed.py
+++ b/csvkit/convert/fixed.py
@@ -26,7 +26,7 @@ def fixed2csv(f, schema, output=None, **kwargs):
     except KeyError:
         encoding = None
 
-    writer = CSVKitWriter(output)
+    writer = CSVKitWriter(output, **kwargs)
 
     reader = FixedWidthReader(f, schema, encoding=encoding)
     writer.writerows(reader)

--- a/csvkit/convert/geojs.py
+++ b/csvkit/convert/geojs.py
@@ -45,7 +45,7 @@ def geojson2csv(f, key=None, **kwargs):
     header.append('geojson')
 
     o = StringIO()
-    writer = CSVKitWriter(o)
+    writer = CSVKitWriter(o, **kwargs)
 
     writer.writerow(header)
 

--- a/csvkit/convert/js.py
+++ b/csvkit/convert/js.py
@@ -56,7 +56,7 @@ def json2csv(f, key=None, **kwargs):
     fields = sorted(list(field_set))
 
     o = StringIO()
-    writer = CSVKitWriter(o)
+    writer = CSVKitWriter(o, **kwargs)
 
     writer.writerow(fields)
 

--- a/csvkit/convert/xls.py
+++ b/csvkit/convert/xls.py
@@ -127,6 +127,7 @@ def xls2csv(f, **kwargs):
     book = xlrd.open_workbook(file_contents=f.read())
     if 'sheet' in kwargs:
         sheet = book.sheet_by_name(kwargs['sheet'])
+        kwargs.pop('sheet')
     else:
         sheet = book.sheet_by_index(0)
 

--- a/csvkit/convert/xls.py
+++ b/csvkit/convert/xls.py
@@ -146,7 +146,7 @@ def xls2csv(f, **kwargs):
         tab.append(column)
 
     o = StringIO()
-    output = tab.to_csv(o)
+    output = tab.to_csv(o, **kwargs)
     output = o.getvalue()
     o.close()
 

--- a/csvkit/convert/xlsx.py
+++ b/csvkit/convert/xlsx.py
@@ -33,13 +33,14 @@ def xlsx2csv(f, output=None, **kwargs):
     if not streaming:
         output = StringIO()
 
-    writer = CSVKitWriter(output, **kwargs)
-
     book = load_workbook(f, use_iterators=True)
     if 'sheet' in kwargs:
         sheet = book.get_sheet_by_name(kwargs['sheet'])
+        kwargs.pop('sheet')
     else:
         sheet = book.get_active_sheet()
+
+    writer = CSVKitWriter(output, **kwargs)
 
     for i, row in enumerate(sheet.iter_rows()):
         if i == 0:

--- a/csvkit/convert/xlsx.py
+++ b/csvkit/convert/xlsx.py
@@ -33,7 +33,7 @@ def xlsx2csv(f, output=None, **kwargs):
     if not streaming:
         output = StringIO()
 
-    writer = CSVKitWriter(output)
+    writer = CSVKitWriter(output, **kwargs)
 
     book = load_workbook(f, use_iterators=True)
     if 'sheet' in kwargs:

--- a/csvkit/unicsv.py
+++ b/csvkit/unicsv.py
@@ -78,6 +78,17 @@ class UnicodeCSVWriter(object):
             self.encoder = codecs.getincrementalencoder(encoding)()
 
     def writerow(self, row):
+        ### HACK: Work around for unresolved issue in csv module http://bugs.python.org/issue12178
+        escapechar = self.writer.dialect.escapechar
+        if escapechar != None:
+            fixed_row = []
+            for s in row:
+                if isinstance(s, (str, unicode)):
+                    fixed_row.append(s.replace(escapechar,(escapechar + escapechar)))
+                else:
+                    fixed_row.append(s)
+            row = fixed_row
+        ###
         if self._eight_bit:
             self.writer.writerow([unicode(s if s != None else '').encode(self.encoding) for s in row])
         else:


### PR DESCRIPTION
The quote characters were never being escaped because doublequote could never be False. Some changes to csvkit/cli.py were needed because all of the attributes of self.args that we are checking for in the CSVKitUtility class already exist so the 'if' statements should be checking that the attributes are not None type instead of simply checking that they exist. This fixes the problem where 'doublequote=False' is never passed into kwargs.

A bug in the Python built-in csv class does not escape the escapechar when writing out with csv.writer. See http://bugs.python.org/issue12178. I have added a few lines as a work-around in csvkit/unicsv.py for UnicodeCSVWriter.writerow(). In the event that the bug is finally fixed in Python, just remove the 10 lines that I've added.