### PR TITLE
fix encoding issue for chinese(Non-English) Column passed from commandli...

### DIFF
--- a/csvkit/cli.py
+++ b/csvkit/cli.py
@@ -6,6 +6,7 @@ import codecs
 import gzip
 import os.path
 import sys
+import chardet
 
 import six
 
@@ -331,6 +332,14 @@ def parse_column_identifiers(ids, column_names, zero_based=False, excluded_colum
         return columns
 
     if not columns:
+
+        try:
+            if isinstance(ids, unicode) == True:
+                encoding = chardet.detect(ids)["encoding"]
+                ids = unicode(ids, encoding)
+        except NameError:
+            pass
+
         for c in ids.split(','):
             c = c.strip()
 
@@ -363,6 +372,14 @@ def parse_column_identifiers(ids, column_names, zero_based=False, excluded_colum
     excludes = []
     
     if excluded_columns:
+
+        try:
+            if isinstance(ids, unicode) == True:
+                encoding = chardet.detect(excluded_columns)["encoding"]
+                excluded_columns = unicode(excluded_columns, encoding)
+        except NameError:
+            pass
+
         for c in excluded_columns.split(','):
             c = c.strip()
 

--- a/requirements-py2.txt
+++ b/requirements-py2.txt
@@ -13,3 +13,4 @@ six>=1.6.1
 ordereddict>=1.1
 simplejson>=3.6.3
 sphinx_rtd_theme
+chardet

--- a/requirements-py3.txt
+++ b/requirements-py3.txt
@@ -8,3 +8,4 @@ openpyxl>=2.0.3
 tox>=1.3
 six>=1.6.1
 sphinx_rtd_theme
+chardet


### PR DESCRIPTION
if u  pass the chinese column to csvcut -c <HERE>（It also affect csvgrep, csvsort, csvjoin,...）, It will cause the proble as followed，because It can't process input encoding from command，

```
$ in2csv userinfos20140819.xls 
id,<中文1>,<中文2>
1,1212,88
1,1111,89
$ in2csv userinfos20140819.xls csvcut -c <中文1>,<中文2>
.....
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe5 in position 19: ordinal not in range(128)
Original exception was:
.....
    raise ColumnIdentifierError('Column identifier "%s" is neither an integer, nor a existing column\'s name.' % c)
```