### PR TITLE
Correct the help text for csvsort so that the text for the -c|--columns ...

### DIFF
--- a/csvkit/utilities/csvsort.py
+++ b/csvkit/utilities/csvsort.py
@@ -15,7 +15,7 @@ class CSVSort(CSVKitUtility):
         self.argparser.add_argument('-n', '--names', dest='names_only', action='store_true',
             help='Display column names and indices from the input CSV and exit.')
         self.argparser.add_argument('-c', '--columns', dest='columns',
-            help='A comma separated list of column indices or names to be extracted. Defaults to all columns.')
+            help='A comma separated list of column indices or names to sort by. Defaults to the first column.')
         self.argparser.add_argument('-r', '--reverse', dest='reverse', action='store_true',
             help='Sort in descending order.')
         self.argparser.add_argument('--no-inference', dest='no_inference', action='store_true',


### PR DESCRIPTION
...option mentions that the columns passed in are the order the script will sort by