### PR TITLE
Fix #379 in2csv --no-inference use infer_types

### DIFF
--- a/csvkit/utilities/in2csv.py
+++ b/csvkit/utilities/in2csv.py
@@ -64,7 +64,7 @@ class In2CSV(CSVKitUtility):
             kwargs['sheet'] = self.args.sheet
 
         if self.args.no_inference:
-            kwargs['type_inference'] = False
+            kwargs['infer_types'] = False
 
         if filetype == 'csv' and self.args.no_header_row:
             kwargs['no_header_row'] = True


### PR DESCRIPTION
It looks like in2csv was just using the wrong kwarg.

Changed --no-inference to set infer_types like table.py does, not type_inference.
