### PR TITLE
fixed index out of range on bad files

### DIFF
--- a/csvkit/grep.py
+++ b/csvkit/grep.py
@@ -66,8 +66,14 @@ class FilteringCSVReader(six.Iterator):
             if self.any_match and test(row[idx]):
                 return not self.inverse # True
 
-            if not self.any_match and not test(row[idx]):
-                return self.inverse # False
+            """
+            Handle bad data files?
+            """
+            try:
+	            if not self.any_match and not test(row[idx]):
+	                return self.inverse # False
+            except:
+            	return self.inverse # False
 
         return not self.inverse # True
         


### PR DESCRIPTION
Not sure if this is the 'proper' fix or not, however, I was using csvkit to grok a ugly CSV file from a client and was constantly getting a index out of range when running:

    csvgrep -m "inspiring ideas to discover." -c 4 EK_ContentTableDump.csv

It failed in my case with a 'index out of range'.  I added a try/catch around it and it seems to work (properly) now.

  


