### PR TITLE
Add support for phabricator styled output

### DIFF
--- a/csvkit/utilities/csvlook.py
+++ b/csvkit/utilities/csvlook.py
@@ -12,7 +12,8 @@ class CSVLook(CSVKitUtility):
     description = 'Render a CSV file in the console as a fixed-width table.'
 
     def add_arguments(self):
-        pass
+        self.argparser.add_argument('--phabricator', '-P', action='store_true', dest='phabricator',
+            help='Use phabricator styled output.')
 
     def main(self):
         rows = CSVKitReader(self.input_file, **self.reader_kwargs)
@@ -52,9 +53,13 @@ class CSVLook(CSVKitUtility):
                 except IndexError:
                     widths.append(len(v))
 
-        # Dashes span each width with '+' character at intersection of
-        # horizontal and vertical dividers.
-        divider = '|--' + '-+-'.join('-'* w for w in widths) + '--|'
+        if self.args.phabricator:
+            # Use phabricator styled headers for direct copying
+            divider = '|--' + '-|-'.join('-'* w for w in widths) + '--|'
+        else:
+            # Dashes span each width with '+' character at intersection of
+            # horizontal and vertical dividers.
+            divider = '|--' + '-+-'.join('-'* w for w in widths) + '--|'
 
         self.output_file.write('%s\n' % divider)
 
@@ -66,9 +71,10 @@ class CSVLook(CSVKitUtility):
                     d = ''
                 output.append(' %s ' % six.text_type(d).ljust(widths[j]))
 
-            self.output_file.write('| %s |\n' % ('|'.join(output)))
+            self.output_file.write('| %s |\n'
+ % ('|'.join(output)))
 
-            if (i == 0 or i == len(rows) - 1):
+            if (i == 0) or (not self.args.phabricator and i == len(rows) - 1):
                 self.output_file.write('%s\n' % divider)
 
 def launch_new_instance():

--- a/tests/test_utilities/test_csvlook.py
+++ b/tests/test_utilities/test_csvlook.py
@@ -26,6 +26,23 @@ class TestCSVLook(unittest.TestCase):
         self.assertEqual(next(input_file), '|  1 | 2 | 3  |\n')
         self.assertEqual(next(input_file), '|  1 | 4 | 5  |\n')
         self.assertEqual(next(input_file), '|----+---+----|\n')
+        self.assertRaises(StopIteration, next, input_file)
+
+    def test_phabricator(self):
+        args = ['examples/dummy3.csv', '--phabricator']
+        output_file = six.StringIO()
+        utility = CSVLook(args, output_file)
+
+        utility.main()
+
+        input_file = six.StringIO(output_file.getvalue())
+
+        self.assertEqual(next(input_file), '|----|---|----|\n')
+        self.assertEqual(next(input_file), '|  a | b | c  |\n')
+        self.assertEqual(next(input_file), '|----|---|----|\n')
+        self.assertEqual(next(input_file), '|  1 | 2 | 3  |\n')
+        self.assertEqual(next(input_file), '|  1 | 4 | 5  |\n')
+        self.assertRaises(StopIteration, next, input_file)
 
     def test_no_header(self):
         args = ['--no-header-row', 'examples/no_header_row3.csv']
@@ -42,6 +59,7 @@ class TestCSVLook(unittest.TestCase):
         self.assertEqual(next(input_file), '|  1       | 2       | 3        |\n')
         self.assertEqual(next(input_file), '|  4       | 5       | 6        |\n')
         self.assertEqual(next(input_file), '|----------+---------+----------|\n')
+        self.assertRaises(StopIteration, next, input_file)
 
     def test_unicode(self):
         args = ['examples/test_utf8.csv']
@@ -59,4 +77,5 @@ class TestCSVLook(unittest.TestCase):
         self.assertEqual(next(input_file), '|  1 | 2 | 3  |\n')
         self.assertEqual(next(input_file), u'|  4 | 5 | ʤ  |\n')
         self.assertEqual(next(input_file), '|----+---+----|\n')
+        self.assertRaises(StopIteration, next, input_file)
 


### PR DESCRIPTION
Add support for outputting results according to the table style defined in Phabricator's [Remarkup Syntax](https://secure.phabricator.com/book/phabricator/article/remarkup/#tables). This allows a convenient mechanism of directly copying the output of csvlook to a Phabricator comment/story/wiki page.

For Example:

    csvlook -P example.csv | xsel -i -b

Then just paste the results directly to see your table already formatted for you!
