### PR TITLE
csvjson tries to cast to float

### DIFF
--- a/csvkit/utilities/csvjson.py
+++ b/csvkit/utilities/csvjson.py
@@ -120,6 +120,10 @@ class CSVJSON(CSVKitUtility):
                     elif id_column is not None and i == id_column:
                         geoid = c
                     else:
+                        try:
+                            c = float(c)
+                        except:
+                            pass
                         properties[column_names[i]] = c
 
                 if id_column is not None:


### PR DESCRIPTION
Fixes #412. Here's a quick fix that does not change the `csvjson` interface and tries to cast every property to a float before falling back to a string.