### PR TITLE
Documenation for --no-header-row default column names (csvsql)

### DIFF
--- a/docs/scripts/csvsql.rst
+++ b/docs/scripts/csvsql.rst
@@ -83,3 +83,5 @@ Create tables for an entire folder of CSVs and import data from those files dire
 You can also use CSVSQL to "directly" query one or more CSV files. Please note that this will create an in-memory SQL database, so it won't be very fast::
 
     $ csvsql --query  "select m.usda_id, avg(i.sepal_length) as mean_sepal_length from iris as i join irismeta as m on (i.species = m.species) group by m.species" examples/iris.csv examples/irismeta.csv
+
+If ``--no-header-row`` is used, columns can be referred to by ``column1, column2, ...``


### PR DESCRIPTION
This should probaly also be documented in docs/common_arguments.rst too, but I'm not sure what the implications are for the other tools?

Maybe something like:

    -H, --no-header-row   Specifies that the input CSV file has no header row. A header with column names "column1, ..." will be created

If that makes sense across all tools