### PR TITLE
fixed AttributeError with -n argument for utils with -H suppressed

### DIFF
--- a/csvkit/cli.py
+++ b/csvkit/cli.py
@@ -267,7 +267,7 @@ class CSVKitUtility(object):
         """
         Pretty-prints the names and indices of all columns to a file-like object (usually sys.stdout).
         """
-        if self.args.no_header_row:
+        if getattr(self.args, 'no_header_row', None):
             raise RequiredHeaderError('You cannot use --no-header-row with the -n or --names options.')
 
         f = self.input_file

--- a/tests/test_utilities/test_csvgrep.py
+++ b/tests/test_utilities/test_csvgrep.py
@@ -82,3 +82,16 @@ class TestCSVGrep(unittest.TestCase):
         utility = CSVGrep(args, output_file)
 
         self.assertRaises(ColumnIdentifierError, utility.main)
+
+    def test_display_column_names(self):
+        args = ['-n', 'examples/realdata/FY09_EDU_Recipients_by_State.csv']
+        output_file = six.StringIO()
+
+        utility = CSVGrep(args, output_file)
+        utility.main()
+
+        input_file = six.StringIO(output_file.getvalue())
+        reader = CSVKitReader(input_file)
+
+        self.assertEqual(next(reader), ['  1: State Name'])
+        self.assertEqual(next(reader), ['  2: State Abbreviate'])


### PR DESCRIPTION
This fixes an issue where utilities without the `--no-header-row` option (such as csvgrep) throw an AttributeError when run with the `--names` option.

Using `getattr` with a default value of `None` shouldn't have any other consequences, since if `no_header_row` is missing from the `argparse.Namespace` object, there can't be a conflict between `--names` and  `--no-header-row`.

This fixes #254 and #279. The same problem is mentioned in #399, but I believe this is a more complete fix.

Also added a test for the `--names` flag.