### PR TITLE
Small typo in the docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,7 +32,7 @@ Reorder columns::
 
     csvcut -c column_c,column_a data.csv > new.csv
 
-Find rows with matching ells::
+Find rows with matching cells::
 
     csvgrep -c phone_number -r 555-555-\d{4}" data.csv > matching.csv
 


### PR DESCRIPTION
I noticed a typo in `docs/index.rst`: "matching ells" => "matching cells"

(PS: Thanks for making `csvkit`, it's awesome!)