### PR TITLE
add support for custom sqlalchemy dialects in create table statements

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 0.9.2
 -----
 
+* Add support for custom sqlalchemy dialects.
 
 
 0.9.1

--- a/csvkit/sql.py
+++ b/csvkit/sql.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python
 
+from pkg_resources import iter_entry_points
+
 import datetime
 
 import six
 
-from sqlalchemy import Column, MetaData, Table, create_engine
+from sqlalchemy import Column, MetaData, Table, create_engine, dialects
 from sqlalchemy import BigInteger, Boolean, Date, DateTime, Float, Integer, String, Time
 from sqlalchemy.schema import CreateTable
 
@@ -22,6 +24,9 @@ DIALECTS = {
     'sqlite': 'sqlite.pysqlite',
     'sybase': 'sybase.pyodbc'
 }
+
+DIALECTS.update(dict((e.name, e.module_name)
+                     for e in iter_entry_points('sqlalchemy.dialects')))
 
 NULL_COLUMN_MAX_LENGTH = 32
 SQL_INTEGER_MAX = 2147483647
@@ -52,7 +57,7 @@ def make_column(column, no_constraints=False):
         column_min = min([v for v in column if v is not None])
 
         if column_max > SQL_INTEGER_MAX or column_min < SQL_INTEGER_MIN:
-            sql_column_type = BigInteger 
+            sql_column_type = BigInteger
         else:
             sql_column_type = Integer
     else:
@@ -93,10 +98,8 @@ def make_create_table_statement(sql_table, dialect=None):
     Generates a CREATE TABLE statement for a sqlalchemy table.
     """
     if dialect:
-        module = __import__('sqlalchemy.dialects.%s' % DIALECTS[dialect], fromlist=['dialect'])
-        sql_dialect = module.dialect()
+        sql_dialect = dialects.registry.load(dialect)()
     else:
         sql_dialect = None
 
     return six.text_type(CreateTable(sql_table).compile(dialect=sql_dialect)).strip() + ';'
-


### PR DESCRIPTION
Currently, creating table statements is limited to SQLAlchemy's built-in dialects. This patch substitutes loading  dialects via `sqlalchemy.dialects.registry` for `__importing__` from `sqlalchemy.dialects.name`. This allows for loading dialects added via setuptools `entry_points`. For example `pip install pyhive`, which I tested with, provides SQLAlchemy dialects for Hive and Presto.