### PR TITLE
csvstack accepts single file without errors

### DIFF
--- a/csvkit/utilities/csvstack.py
+++ b/csvkit/utilities/csvstack.py
@@ -14,7 +14,7 @@ class CSVStack(CSVKitUtility):
         self.argparser.add_argument(metavar="FILE", nargs='+', dest='input_paths', default=['-'],
             help='The CSV file(s) to operate on. If omitted, will accept input on STDIN.')
         self.argparser.add_argument('-g', '--groups', dest='groups',
-            help='A comma-seperated list of values to add as "grouping factors", one for each CSV being stacked. These will be added to the stacked CSV as a new column. You may specify a name for the grouping column using the -n flag.')
+            help='A comma-separated list of values to add as "grouping factors", one for each CSV being stacked. These will be added to the stacked CSV as a new column. You may specify a name for the grouping column using the -n flag.')
         self.argparser.add_argument('-n', '--group-name', dest='group_name',
             help='A name for the grouping column, e.g. "year". Only used when also specifying -g.')
         self.argparser.add_argument('--filenames', dest='group_by_filenames', action='store_true',

--- a/csvkit/utilities/csvstack.py
+++ b/csvkit/utilities/csvstack.py
@@ -26,8 +26,8 @@ class CSVStack(CSVKitUtility):
         for path in self.args.input_paths:
             self.input_files.append(self._open_input_file(path))
 
-        if len(self.input_files) < 2:
-            self.argparser.error('You must specify at least two files to stack.')
+        if not self.input_files:
+            self.argparser.error('You must specify at least one file to stack.')
 
         if self.args.group_by_filenames:
             groups = [os.path.split(f.name)[1] for f in self.input_files] 

--- a/tests/test_utilities/test_csvstack.py
+++ b/tests/test_utilities/test_csvstack.py
@@ -11,6 +11,39 @@ from csvkit import CSVKitReader
 from csvkit.utilities.csvstack import CSVStack
 
 class TestCSVStack(unittest.TestCase):
+    def test_single_file_stack(self):
+        # stacking single file works fine
+        args = ['examples/dummy.csv']
+
+        output_file = six.StringIO()
+        utility = CSVStack(args, output_file)
+
+        utility.main()
+
+        # verify the stacked file's contents
+        input_file = six.StringIO(output_file.getvalue())
+        reader = CSVKitReader(input_file)
+
+        self.assertEqual(next(reader), ['a', 'b', 'c'])
+        self.assertEqual(next(reader)[0], '1')
+
+    def test_multiple_file_stack(self):
+        # stacking multiple files works fine
+        args = ['examples/dummy.csv', 'examples/dummy2.csv']
+
+        output_file = six.StringIO()
+        utility = CSVStack(args, output_file)
+
+        utility.main()
+
+        # verify the stacked file's contents
+        input_file = six.StringIO(output_file.getvalue())
+        reader = CSVKitReader(input_file)
+
+        self.assertEqual(next(reader), ['a', 'b', 'c'])
+        self.assertEqual(next(reader)[0], '1')
+        self.assertEqual(next(reader)[0], '1')
+
     def test_explicit_grouping(self):
         # stack two CSV files
         args = ['--groups', 'asd,sdf', '-n', 'foo', 'examples/dummy.csv', 'examples/dummy2.csv']


### PR DESCRIPTION
Original issue reported on #414. Came across same need while running csvstack on automated jenkins jobs and went for the fix, having not seen strong reasons why it cannot accept single files. Added couple of basic tests testing basic csvstack functionality with one file and with multiple files.

Closes #414 