### PR TITLE
Normalize column names when generating SQL

### DIFF
--- a/csvkit/table.py
+++ b/csvkit/table.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-
 import datetime
 import itertools
 
@@ -11,22 +10,27 @@ from csvkit import typeinference
 from csvkit.cli import parse_column_identifiers
 from csvkit.headers import make_default_headers
 
+
 class InvalidType(object):
     """
-    Dummy object type for Column initialization, since None is being used as a valid value.
+    Dummy object type for Column initialization, since None is being used as a
+    valid value.
     """
     pass
+
 
 class Column(list):
     """
     A normalized data column and inferred annotations (nullable, etc.).
     """
-    def __init__(self, order, name, l, normal_type=InvalidType, blanks_as_nulls=True, infer_types=True):
+    def __init__(self, order, name, l, normal_type=InvalidType,
+                 blanks_as_nulls=True, infer_types=True):
         """
         Construct a column from a sequence of values.
 
-        If normal_type is not InvalidType, inference will be skipped and values assumed to have already been normalized.
-        If infer_types is False, type inference will be skipped and the type assumed to be unicode.
+        If normal_type is not InvalidType, inference will be skipped and values
+        assumed to have already been normalized. If infer_types is False, type
+        inference will be skipped and the type assumed to be unicode.
         """
         if normal_type != InvalidType:
             t = normal_type
@@ -39,7 +43,7 @@ class Column(list):
 
         list.__init__(self, data)
         self.order = order
-        self.name = name or '_unnamed' # empty column names don't make sense
+        self.name = name or '_unnamed'  # empty column names don't make sense
         self.type = t
 
     def __str__(self):
@@ -53,7 +57,8 @@ class Column(list):
 
     def __getitem__(self, key):
         """
-        Return null for keys beyond the range of the column. This allows for columns to be of uneven length and still be merged into rows cleanly.
+        Return null for keys beyond the range of the column. This allows for
+        columns to be of uneven length and still be merged into rows cleanly.
         """
         l = len(self)
 
@@ -88,13 +93,16 @@ class Column(list):
 
         return l
 
+
 class Table(list):
     """
     A normalized data table and inferred annotations (nullable, etc.).
     """
+
     def __init__(self, columns=[], name='new_table'):
         """
-        Generic constructor. You should normally use a from_* method to create a Table.
+        Generic constructor. You should normally use a from_* method to create
+        a Table.
         """
         list.__init__(self, columns)
         self.name = name
@@ -187,14 +195,16 @@ class Table(list):
         return row_data
 
     @classmethod
-    def from_csv(cls, f, name='from_csv_table', snifflimit=None, column_ids=None, blanks_as_nulls=True, zero_based=False, infer_types=True, no_header_row=False, **kwargs):
-        """
-        Creates a new Table from a file-like object containing CSV data.
+    def from_csv(cls, f, name='from_csv_table', snifflimit=None,
+                 column_ids=None, blanks_as_nulls=True, zero_based=False,
+                 infer_types=True, no_header_row=False, **kwargs):
+        """ Creates a new Table from a file-like object containing CSV data.
 
-        Note: the column_ids argument will cause only those columns with a matching identifier
-        to be parsed, type inferred, etc. However, their order/index property will reflect the
-        original data (e.g. column 8 will still be "order" 7, even if it's the third column
-        in the resulting Table.
+        Note: the column_ids argument will cause only those columns with a
+        matching identifier to be parsed, type inferred, etc. However, their
+        order/index property will reflect the original data (e.g. column 8
+        will still be "order" 7, even if it's the third column in the resulting
+        Table.
         """
         # This bit of nonsense is to deal with "files" from stdin,
         # which are not seekable and thus must be buffered
@@ -214,7 +224,8 @@ class Table(list):
             row = next(rows)
 
             headers = make_default_headers(len(row))
-            column_ids = parse_column_identifiers(column_ids, headers, zero_based)
+            column_ids = parse_column_identifiers(column_ids, headers,
+                                                  zero_based)
             headers = [headers[c] for c in column_ids]
             data_columns = [[] for c in headers]
 
@@ -224,7 +235,8 @@ class Table(list):
             headers = next(rows)
 
             if column_ids:
-                column_ids = parse_column_identifiers(column_ids, headers, zero_based)
+                column_ids = parse_column_identifiers(column_ids, headers,
+                                                      zero_based)
                 headers = [headers[c] for c in column_ids]
             else:
                 column_ids = range(len(headers))
@@ -254,7 +266,9 @@ class Table(list):
         columns = []
 
         for i, c in enumerate(data_columns):
-            columns.append(Column(column_ids[i], headers[i], c, blanks_as_nulls=blanks_as_nulls, infer_types=infer_types))
+            columns.append(Column(column_ids[i], headers[i], c,
+                                  blanks_as_nulls=blanks_as_nulls,
+                                  infer_types=infer_types))
 
         return Table(columns, name=name)
 

--- a/csvkit/utilities/csvsql.py
+++ b/csvkit/utilities/csvsql.py
@@ -9,8 +9,11 @@ from csvkit import sql
 from csvkit import table
 from csvkit.cli import CSVKitUtility
 
+
 class CSVSQL(CSVKitUtility):
-    description = 'Generate SQL statements for one or more CSV files, create execute those statements directly on a database, and execute one or more SQL queries.'
+    description = ("Generate SQL statements for one or more CSV files, create "
+                   "execute those statements directly on a database, and "
+                   "execute one or more SQL queries.")
     override_flags = ['l', 'f']
 
     def add_arguments(self):
@@ -155,6 +158,7 @@ class CSVSQL(CSVKitUtility):
 
             trans.commit()
             conn.close()
+
 
 def launch_new_instance():
     utility = CSVSQL()

--- a/csvkit/utilities/csvsql.py
+++ b/csvkit/utilities/csvsql.py
@@ -4,6 +4,7 @@ import os
 import sys
 
 import agate
+from normality import slugify
 
 from csvkit import sql
 from csvkit import table
@@ -24,6 +25,8 @@ class CSVSQL(CSVKitUtility):
             help='Limit CSV dialect sniffing to the specified number of bytes. Specify "0" to disable sniffing entirely.')
         self.argparser.add_argument('-i', '--dialect', dest='dialect', choices=sql.DIALECTS,
             help='Dialect of SQL to generate. Only valid when --db is not specified.')
+        self.argparser.add_argument('-n', '--normalize-columns', dest='normalize_columns', action='store_true',
+            help='Normalize the headers before generating column names.')
         self.argparser.add_argument('--db', dest='connection_string',
             help='If present, a sqlalchemy connection string to use to directly execute generated SQL on a database.')
         self.argparser.add_argument('--query', default=None,
@@ -118,7 +121,8 @@ class CSVSQL(CSVKitUtility):
                     table_name,
                     self.args.no_constraints,
                     self.args.db_schema,
-                    metadata
+                    self.args.normalize_columns,
+                    metadata,
                 )
 
                 # Create table
@@ -129,11 +133,14 @@ class CSVSQL(CSVKitUtility):
                 if do_insert and csv_table.count_rows() > 0:
                     insert = sql_table.insert()
                     headers = csv_table.headers()
+                    if self.args.normalize_columns:
+                        headers = [slugify(h, sep='_') for h in headers]
                     conn.execute(insert, [dict(zip(headers, row)) for row in csv_table.to_rows()])
 
             # Output SQL statements
             else:
-                sql_table = sql.make_table(csv_table, table_name, self.args.no_constraints)
+                sql_table = sql.make_table(csv_table, table_name,
+                                           self.args.no_constraints)
                 self.output_file.write('%s\n' % sql.make_create_table_statement(sql_table, dialect=self.args.dialect))
 
         if connection_string:

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ install_requires = [
     'sqlalchemy>=0.6.6',
     'openpyxl==2.2.6',
     'six>=1.6.1',
+    'normality>=0.2.4',
     'python-dateutil==2.2',
     'dbf>=0.96.005'
 ]


### PR DESCRIPTION
This fixes #396 by introducing a ``--normalize-columns`` flag. The more radical way to implement it would have been to actually make the change in ``Column``, so that it would apply to all ``csvkit`` operations. 

Apologies for the PEP8 things, they just irritate when editing. Can make a clean patch, too. 