### PR TITLE
Add support for custom SQLAlchemy dialects

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -65,3 +65,4 @@ The following individuals have contributed code to csvkit:
 * Kev++
 * edwardros
 * Martin Burch
+* Pedro Silva

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,6 +26,7 @@ Fixes:
 * in2csv again supports nested JSON objects (fixes regression).
 * csvgrep can match multiline values.
 * csvgrep supports --no-header-row.
+* csvsql supports custom SQLAlchemy dialects.
 * csvstack supports stacking a single file.
 * FilteringCSVReader's any_match argument works correctly.
 * A file of two empty rows won't raise an error.

--- a/csvkit/sql.py
+++ b/csvkit/sql.py
@@ -1,27 +1,17 @@
 #!/usr/bin/env python
 
 import datetime
+from pkg_resources import iter_entry_points
 
 import six
 
-from sqlalchemy import Column, MetaData, Table, create_engine
+from sqlalchemy import Column, MetaData, Table, create_engine, dialects
 from sqlalchemy import BigInteger, Boolean, Date, DateTime, Float, Integer, String, Time
 from sqlalchemy.schema import CreateTable
 
 NoneType = type(None)
 
-DIALECTS = {
-    'access': 'access.base',
-    'firebird': 'firebird.kinterbasdb',
-    'informix': 'informix.informixdb',
-    'maxdb': 'maxdb.sapdb',
-    'mssql': 'mssql.pyodbc',
-    'mysql': 'mysql.mysqlconnector',
-    'oracle': 'oracle.cx_oracle',
-    'postgresql': 'postgresql.psycopg2',
-    'sqlite': 'sqlite.pysqlite',
-    'sybase': 'sybase.pyodbc'
-}
+DIALECTS = dialects.__all__ + tuple(e.name for e in iter_entry_points('sqlalchemy.dialects'))
 
 NULL_COLUMN_MAX_LENGTH = 32
 SQL_INTEGER_MAX = 2147483647
@@ -97,8 +87,7 @@ def make_create_table_statement(sql_table, dialect=None):
     Generates a CREATE TABLE statement for a sqlalchemy table.
     """
     if dialect:
-        module = __import__('sqlalchemy.dialects.%s' % DIALECTS[dialect], fromlist=['dialect'])
-        sql_dialect = module.dialect()
+        sql_dialect = dialects.registry.load(dialect)()
     else:
         sql_dialect = None
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -28,7 +28,7 @@ If you only want to use agate, install it this way::
 
 .. note::
 
-    Need more speed? If you're running Python 2.6 or 2.7 you can :code:`pip install cdecimal` for a significant speed boost. This isn't installed automatically because it can create additional complications.
+    Need more speed? If you're running Python 2.7 you can :code:`pip install cdecimal` for a significant speed boost. This isn't installed automatically because it can create additional complications.
 
 Developers
 ==========
@@ -55,7 +55,7 @@ Supported platforms
 
 csvkit supports the following versions of Python:
 
-* Python 2.6+
+* Python 2.7+
 * Python 3.3+
 * `PyPy <http://pypy.org/>`_
 

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -115,6 +115,11 @@ class TestSQL(unittest.TestCase):
 \tempty_column VARCHAR(32)
 );""")
 
+    def test_make_create_table_statement_with_dialects(self):
+        for dialect in sql.DIALECTS:
+            sql_table = sql.make_table(self.csv_table, 'csvsql', db_schema='test_schema')
+            statement = sql.make_create_table_statement(sql_table, dialect)
+
     def make_insert_statement(self):
         sql_table = sql.make_table(self.csv_table, 'csvsql')
         statement = sql.make_insert_statement(sql_table, self.csv_table._prepare_rows_for_serialization()[0])


### PR DESCRIPTION
Closes #455 

Also removes support for dialects that have since been dropped from SQLAlchemy. See http://docs.sqlalchemy.org/en/latest/dialects/